### PR TITLE
feat: add medium controller to index posts

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -3297,6 +3297,11 @@
       "integrity": "sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==",
       "dev": true
     },
+    "xmlhttprequest": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest/-/xmlhttprequest-1.8.0.tgz",
+      "integrity": "sha1-Z/4HXFwk/vOfnWX197f+dRcZaPw="
+    },
     "yallist": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",

--- a/backend/package.json
+++ b/backend/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "express": "^4.17.1",
     "knex": "^0.20.15",
-    "sqlite3": "^4.1.1"
+    "sqlite3": "^4.1.1",
+    "xmlhttprequest": "^1.8.0"
   },
   "devDependencies": {
     "nodemon": "^2.0.3"

--- a/backend/src/controllers/mediumController.js
+++ b/backend/src/controllers/mediumController.js
@@ -1,1 +1,35 @@
-//TODO
+const XMLHttpRequest = require("xmlhttprequest").XMLHttpRequest;
+
+function httpGetFromApi(url) {
+    // function to get JSON responses from an api call
+    var xmlHttp = new XMLHttpRequest();
+    xmlHttp.open("GET", url, false); // false for synchronous request
+    xmlHttp.send(null);
+    return JSON.parse(xmlHttp.responseText);
+}
+
+function removeDescription(json){
+    //remove unused content from the apis response (to use less memory)
+    json['items'].forEach(function(post){
+        delete post['description']
+        delete post['content']
+    })
+    return json;
+}
+
+module.exports = {
+  async index(request, response) {
+    // allow for usage with any user (if any other use is defined), defaults to turing-talks
+    var { user } = request.query;
+    if (user == undefined) { user = 'turing-talks' }
+    // create the default request url, separated so it can be changed if necessary
+    // utilizes the rss2json's api to convert mediums feed to a json
+    let mediumRssUrl = `https://medium.com/feed/${user}`;
+    let rss2jsonUrl = `https://api.rss2json.com/v1/api.json?rss_url=${mediumRssUrl}`;
+    // fetch and remove content/description of response to use less memory
+    let apiResponse = httpGetFromApi(rss2jsonUrl);
+    let cleanJson = removeDescription(apiResponse);
+
+    return response.json(cleanJson);
+  },
+};

--- a/backend/src/routes.js
+++ b/backend/src/routes.js
@@ -3,8 +3,10 @@ const express = require('express');
 const routes = express.Router();
 //controller import
 const membersController = require('./controllers/membersController');
+const mediumController = require('./controllers/mediumController')
 
 routes.get('/members', membersController.index);
 routes.post('/members', membersController.create);
+routes.get('/listMediumPosts', mediumController.index)
 
 module.exports = routes;


### PR DESCRIPTION
Added medium controller (and XMLHttpRequest as requirement) to allow fetching the medium rss feed and convert it into a json utilizing rss2json's api

`/listMediumPosts?user=xxxx` should work for any user and defaults (if none is given) to `turing-talks` on the application